### PR TITLE
Use device-basic endpoint to get full list of devices

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -49,12 +49,14 @@ class Controller {
 
 	public function devices($data = null) {
 		try {
-			$devices = $this->api->get('/api/s/' . $this->site_id . '/stat/device', $data);
+			$devices = $this->api->get('/api/s/' . $this->site_id . '/stat/device-basic', $data);
 		} catch (ClientException $e) {
 			return null;
 		}
 		return array_map(function ($device) {
 				// figure out the type of device we're working with and return an instance of that, otherwise just return the default "device" object.
+				$full_info = $this->api->get('/api/s/' . $this->site_id . '/stat/device', ['macs' => [$device->mac]]);
+				$device->model = $full_info[0]->model;
 				switch ($device->model) {
 					case 'U2IW':
 					case 'U7IW':


### PR DESCRIPTION
This returns a lot less data - if you have too many APs
the the full device list can cause memory problems. It is less
efficient as it needs n+1 API calls, but still seems pretty quick